### PR TITLE
Updated find command to accept multiple arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
     compile group: 'com.joestelmach', name: 'natty', version: '0.13'
+    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.28'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -434,8 +434,8 @@ Use case resumes at step 2.
 
 *MSS*
 
-1.  User requests to find all occurrences of a keyword or within a cost range or date range in a spending.
-2.  MoneyGoWhere returns any spending found with the keyword or within a cost range or date range specified.
+1.  User requests to find all occurrences of entered keywords, optionally within the spending name, a cost range, date range, remark and tag in a spending.
+2.  MoneyGoWhere returns any spending found with the keywords contained within its cost range, date range, remark and tag specified.
 +
 Use case ends.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -167,7 +167,7 @@ Displays the list of spending tagged with `groceries` in `descending order by da
 
 Searches for spending based on given keywords, cost range and date range. +
 At least one search field must be present. +
-Format: `find [n/NAME_KEYWORDS] [c/COST_MIN-COST_MAX] [d/DATE_START - DATE_END] [r/REMARK_KEYWORDS] [t/TAG_KEYWORDS]`
+Format: `find [n/NAME_KEYWORDS] [c/COST_MIN-COST_MAX] [d/DATE_START - DATE_END] [r/REMARK_KEYWORDS] [t/TAG]...`
 
 Example:
 
@@ -283,7 +283,7 @@ e.g. `update i/123 n/apple c/2.50 d/yesterday t/fruits r/expensive apple`
 | *Delete* | `delete INDEX` +
 e.g. `delete 123`
 | *Find* | `find [n/NAME] [c/COST_RANGE] [d/DATE_RANGE] [r/REMARK] [t/TAG]` +
-e.g. `find n/apple orange c/1.00-200 d/19/09/2019 - 20/09/2019 r/healthy food t/fruit`
+e.g. `find n/apple orange c/1.00-200 d/19/09/2019 - 20/09/2019 r/healthy food t/fruit food`
 | *List* | `list [r/DATE_RANGE] [t/TAG] [c/COST_RANGE] [o/SORT_ORDER]` +
 e.g. `list r/01/09/2019-30/09/2019 t/groceries c/20-100 o/ASC`
 | *Budget* | `budget m/MONTHLY_BUDGET` +

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -102,6 +102,7 @@ Examples:
 * `add n/chicken breast c/1.80 t/meat` +
 * `add n/coffee c/1.20 d/today` +
 * `add n/milo c/1.50 r/I love milo` +
+* `add n/gold class movie ticket d/15/1/2019 c/13.00 r/important t/entertainment` +
 
 === Updating a spending : `update`
 
@@ -165,12 +166,15 @@ Displays the list of spending tagged with `groceries` in `descending order by da
 === Find by keyword : `find`
 
 Searches for spending based on given keywords, cost range and date range. +
-Format: `find KEYWORD [MORE_KEYWORDS] [c/COST_RANGE] [r/DATE_RANGE]`
+At least one search field must be present. +
+Format: `find [n/NAME_KEYWORDS] [c/COST_MIN-COST_MAX] [d/DATE_START - DATE_END] [r/REMARK_KEYWORDS] [t/TAG_KEYWORDS]`
 
 Example:
 
-* `find book Java c/100-150 r/01/09/2019-30/09/2019` +
-Returns a list of spending with `book` and `Java` keywords within the cost range `100-150` and date range within `01/09/2019-30/09/2019`.
+* `find n/Java book c/100.20-150 r/01/09/2019 - 30/09/2019` +
+Returns a list of spending with `Java` and `book` keywords within the cost range `100.20-150` and date range within `01/09/2019 - 30/09/2019`.
+* `find n/apple c/1.50-2.00 r/01/09/2019 to 30/09/2019` +
+Returns a list of spending with `apple` keyword within the cost range `1.50-2.00` and date range within `01/09/2019 to 30/09/2019`.
 
 === Setting monthly budget : `budget`
 Sets a monthly budget for the current month in Singapore dollars. +
@@ -278,8 +282,8 @@ e.g. `add n/apple c/2.50 d/yesterday t/fruits r/expensive apple`
 e.g. `update i/123 n/apple c/2.50 d/yesterday t/fruits r/expensive apple`
 | *Delete* | `delete INDEX` +
 e.g. `delete 123`
-| *Find* | `find KEYWORD [MORE_KEYWORDS] [c/COST_RANGE] [r/DATE_RANGE]` +
-e.g. `find apple orange c/1.00-200 r/19/09/2019-20/09/2019`
+| *Find* | `find [n/NAME] [c/COST_RANGE] [d/DATE_RANGE] [r/REMARK] [t/TAG]` +
+e.g. `find n/apple orange c/1.00-200 d/19/09/2019 - 20/09/2019 r/healthy food t/fruit`
 | *List* | `list [r/DATE_RANGE] [t/TAG] [c/COST_RANGE] [o/SORT_ORDER]` +
 e.g. `list r/01/09/2019-30/09/2019 t/groceries c/20-100 o/ASC`
 | *Budget* | `budget m/MONTHLY_BUDGET` +

--- a/src/main/java/seedu/moneygowhere/commons/core/Messages.java
+++ b/src/main/java/seedu/moneygowhere/commons/core/Messages.java
@@ -9,6 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_SPENDING_DISPLAYED_INDEX = "The Spending index provided is invalid";
     public static final String MESSAGE_INVALID_BUDGET_AMOUNT = "The budget amount provided is invalid";
-    public static final String MESSAGE_SPENDINGS_LISTED_OVERVIEW = "%1$d spending listed!";
+    public static final String MESSAGE_SPENDINGS_LISTED_OVERVIEW = "%1$d spending entries listed!";
 
 }

--- a/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
+++ b/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
@@ -58,6 +58,27 @@ public class DateUtil {
     }
 
     /**
+     * Parses a given date in natural language, processes it and returns a formatted date.
+     *
+     * @param date Input date
+     * @return List of formatted dates
+     */
+    public static List<Date> parseDates(String date) {
+        requireNonNull(date);
+
+        // Normalises this date input.
+        String normalisedDate = normaliseDate(date);
+
+        List<DateGroup> dateGroups = PARSER.parse(normalisedDate);
+
+        if (dateGroups.isEmpty()) {
+            return null;
+        }
+
+        return dateGroups.get(0).getDates();
+    }
+
+    /**
      * Checks if an input date is valid.
      *
      * @param date Input date
@@ -113,7 +134,11 @@ public class DateUtil {
                     }
                 }
 
-                builder = new StringBuilder(String.format("%d/%d/%d", year, month, day));
+                if (builder.length() > 0) {
+                    builder.append(" ");
+                }
+
+                builder.append(String.format("%d/%d/%d", year, month, day));
             } else {
                 if (tokens.length == 1) {
                     builder.append(token);

--- a/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
+++ b/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
@@ -2,13 +2,16 @@ package seedu.moneygowhere.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.joestelmach.natty.DateGroup;
 import com.joestelmach.natty.Parser;
@@ -19,8 +22,8 @@ import seedu.moneygowhere.logic.parser.exceptions.ParseException;
  * Contains utility methods used for parsing dates with natural language processing.
  */
 public class DateUtil {
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy");
-    private static final DateFormat DATE_FORMAT_PRETTY = new SimpleDateFormat("EE dd/MM/yyyy");
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+    private static final DateTimeFormatter DATE_FORMAT_PRETTY = DateTimeFormatter.ofPattern("EE dd/MM/yyyy");
 
     /** Date pattern which allows leading zeroes to be omitted. **/
     private static final Pattern DATE_PATTERN = Pattern.compile("([0-9]{1,2})(?:[/\\-])([0-9]{1,2})"
@@ -36,7 +39,7 @@ public class DateUtil {
      * @return Formatted date as Date type
      * @throws ParseException If the input cannot be parsed
      */
-    public static Date parseDate(String date) throws ParseException {
+    public static LocalDate parseDate(String date) throws ParseException {
         requireNonNull(date);
 
         // Normalises this date input.
@@ -54,7 +57,12 @@ public class DateUtil {
             throw new ParseException("No possible dates from input date");
         }
 
-        return possibleDates.get(0);
+        List<LocalDate> convertedDate = dateGroups.get(0).getDates()
+                .stream()
+                .map(d -> d.toInstant().atZone(ZoneId.systemDefault()).toLocalDate())
+                .collect(Collectors.toList());
+
+        return convertedDate.get(0);
     }
 
     /**
@@ -63,7 +71,7 @@ public class DateUtil {
      * @param date Input date
      * @return List of formatted dates
      */
-    public static List<Date> parseDates(String date) {
+    public static List<LocalDate> parseDates(String date) {
         requireNonNull(date);
 
         // Normalises this date input.
@@ -75,7 +83,10 @@ public class DateUtil {
             return null;
         }
 
-        return dateGroups.get(0).getDates();
+        return dateGroups.get(0).getDates()
+                .stream()
+                .map(d -> d.toInstant().atZone(ZoneId.systemDefault()).toLocalDate())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -158,8 +169,8 @@ public class DateUtil {
      * @param date Input date
      * @return A formatted date string
      */
-    public static String formatDate(Date date) {
-        return DATE_FORMAT.format(date);
+    public static String formatDate(LocalDate date) {
+        return date.format(DATE_FORMAT);
     }
 
     /**
@@ -171,9 +182,9 @@ public class DateUtil {
      */
     public static String prettyFormatDate(String date) {
         try {
-            Date parsedDate = DATE_FORMAT.parse(date);
+            LocalDate parsedDate = LocalDate.parse(date, DATE_FORMAT);
             return DATE_FORMAT_PRETTY.format(parsedDate);
-        } catch (java.text.ParseException e) {
+        } catch (DateTimeParseException e) {
             return "";
         }
     }

--- a/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
+++ b/src/main/java/seedu/moneygowhere/commons/util/DateUtil.java
@@ -2,6 +2,7 @@ package seedu.moneygowhere.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -112,6 +113,23 @@ public class DateUtil {
     }
 
     /**
+     * Checks if an input date is valid.
+     *
+     * @param year Year
+     * @param month Month
+     * @param day Day
+     * @return True if the input date was valid.
+     */
+    private static boolean isValidNormalisedDate(int year, int month, int day) {
+        try {
+            LocalDate.of(year, month, day);
+            return true;
+        } catch (DateTimeException e) {
+            return false;
+        }
+    }
+
+    /**
      * Normalises a given date format, from dd/mm/yyyy to yyyy/mm/dd.
      *
      * @param date Date
@@ -143,6 +161,10 @@ public class DateUtil {
                     if (year < 1900) {
                         return "";
                     }
+                }
+
+                if (!isValidNormalisedDate(year, month, day)) {
+                    return "";
                 }
 
                 if (builder.length() > 0) {

--- a/src/main/java/seedu/moneygowhere/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/moneygowhere/logic/commands/FindCommand.java
@@ -2,9 +2,13 @@ package seedu.moneygowhere.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
 import seedu.moneygowhere.commons.core.Messages;
 import seedu.moneygowhere.model.Model;
-import seedu.moneygowhere.model.spending.NameContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.Spending;
 
 /**
  * Finds and lists all spending in MoneyGoWhere whose name contains any of the argument keywords.
@@ -16,27 +20,42 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all spending entries whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Not all fields are necessary, but they are combined together to form a query.\n"
+            + "Parameters: n/KEYWORD [MORE_KEYWORDS]...  d/DATE_RANGE c/COST_RANGE r/REMARK t/TAG\n"
+            + "Example: " + COMMAND_WORD + " n/chicken rice d/1/1/2019 to 2/1/2019 c/1.50-5 r/tasty t/food";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final List<Predicate<Spending>> predicates;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(List<Predicate<Spending>> predicates) {
+        this.predicates = predicates;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredSpendingList(predicate);
+
+        Optional<Predicate<Spending>> predicate = predicates.stream().reduce(Predicate::and);
+
+        if (predicate.isEmpty()) {
+            model.updateFilteredSpendingList(failed -> false);
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_SPENDINGS_LISTED_OVERVIEW, model.getFilteredSpendingList().size()));
+        }
+
+        model.updateFilteredSpendingList(predicate.get());
         return new CommandResult(
                 String.format(Messages.MESSAGE_SPENDINGS_LISTED_OVERVIEW, model.getFilteredSpendingList().size()));
+    }
+
+    @Override
+    public int hashCode() {
+        return predicates.hashCode();
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && predicates.equals(((FindCommand) other).predicates)); // state check
     }
 }

--- a/src/main/java/seedu/moneygowhere/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/moneygowhere/logic/commands/FindCommand.java
@@ -48,11 +48,6 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public int hashCode() {
-        return predicates.hashCode();
-    }
-
-    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls

--- a/src/main/java/seedu/moneygowhere/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/moneygowhere/logic/parser/FindCommandParser.java
@@ -1,12 +1,28 @@
 package seedu.moneygowhere.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.moneygowhere.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_COST;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.moneygowhere.logic.commands.FindCommand;
 import seedu.moneygowhere.logic.parser.exceptions.ParseException;
+import seedu.moneygowhere.model.spending.Cost;
+import seedu.moneygowhere.model.spending.CostInRangePredicate;
+import seedu.moneygowhere.model.spending.Date;
+import seedu.moneygowhere.model.spending.DateInRangePredicate;
 import seedu.moneygowhere.model.spending.NameContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.RemarkContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.Spending;
+import seedu.moneygowhere.model.tag.TagPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +35,51 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DATE, PREFIX_COST, PREFIX_REMARK, PREFIX_TAG);
+
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String name = argMultimap.getValue(PREFIX_NAME).get();
+            String[] nameKeywords = name.split("\\s+");
+            predicates.add(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            List<Date> dates = ParserUtil.parseDates(argMultimap.getAllValues(PREFIX_DATE));
+
+            if (dates.size() < 2) {
+                throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+            }
+            predicates.add(new DateInRangePredicate(dates.get(0), dates.get(1)));
+        }
+        if (argMultimap.getValue(PREFIX_COST).isPresent()) {
+            List<Cost> costs = ParserUtil.parseCosts(argMultimap.getAllValues(PREFIX_COST));
+
+            double min = Double.parseDouble(costs.get(0).value);
+            double max = Double.parseDouble(costs.get(1).value);
+
+            if (costs.size() != 2 || min > max) {
+                throw new ParseException(Cost.MESSAGE_CONSTRAINTS);
+            }
+
+            predicates.add(new CostInRangePredicate(costs.get(0), costs.get(1)));
+        }
+        if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
+            String name = argMultimap.getValue(PREFIX_REMARK).get();
+            String[] nameKeywords = name.split("\\s+");
+            predicates.add(new RemarkContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            String tag = argMultimap.getValue(PREFIX_TAG).get();
+            predicates.add(new TagPredicate(tag));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        if (predicates.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(predicates);
     }
-
 }

--- a/src/main/java/seedu/moneygowhere/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/moneygowhere/logic/parser/FindCommandParser.java
@@ -10,8 +10,10 @@ import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.moneygowhere.logic.commands.FindCommand;
 import seedu.moneygowhere.logic.parser.exceptions.ParseException;
@@ -72,8 +74,9 @@ public class FindCommandParser implements Parser<FindCommand> {
             predicates.add(new RemarkContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            String tag = argMultimap.getValue(PREFIX_TAG).get();
-            predicates.add(new TagPredicate(tag));
+            List<String> tags = argMultimap.getAllValues(PREFIX_TAG);
+            tags = tags.stream().map(String::trim).collect(Collectors.toList());
+            predicates.add(new TagPredicate(new HashSet<>(tags)));
         }
 
         if (predicates.isEmpty()) {

--- a/src/main/java/seedu/moneygowhere/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/moneygowhere/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.moneygowhere.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 
 import seedu.moneygowhere.commons.core.index.Index;
+import seedu.moneygowhere.commons.util.DateUtil;
 import seedu.moneygowhere.commons.util.StringUtil;
 import seedu.moneygowhere.logic.parser.exceptions.ParseException;
 import seedu.moneygowhere.model.budget.Budget;
@@ -73,7 +75,14 @@ public class ParserUtil {
         requireNonNull(dates);
         final List<Date> dateList = new ArrayList<>();
         for (String date : dates) {
-            dateList.add(parseDate(date));
+            List<LocalDate> innerDates = DateUtil.parseDates(date);
+            if (innerDates != null && !innerDates.isEmpty()) {
+                for (LocalDate innerDate : innerDates) {
+                    dateList.add(parseDate(innerDate.toString()));
+                }
+            } else {
+                throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+            }
         }
         return dateList;
     }
@@ -102,6 +111,7 @@ public class ParserUtil {
 
         List<Cost> result = new ArrayList<>();
         for (String tempCost : costs) {
+            tempCost = tempCost.trim();
             String[] costTokens = tempCost.split("-");
             for (String cost : costTokens) {
                 if (!Cost.isValidCost(cost)) {

--- a/src/main/java/seedu/moneygowhere/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/moneygowhere/logic/parser/ParserUtil.java
@@ -83,7 +83,7 @@ public class ParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      * @throws ParseException if the given {@code cost} is invalid.
      */
-    public static Cost parseCost (String cost) throws ParseException {
+    public static Cost parseCost(String cost) throws ParseException {
         requireNonNull(cost);
         String trimmedCost = cost.trim();
         if (!Cost.isValidCost(trimmedCost)) {
@@ -93,11 +93,33 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code String cost} delimited by a '-' into an {@code cost}.
+     * Leading and trailing whitespaces will be trimmed.
+     * @throws ParseException if the given {@code cost} is invalid.
+     */
+    public static List<Cost> parseCosts(Collection<String> costs) throws ParseException {
+        requireNonNull(costs);
+
+        List<Cost> result = new ArrayList<>();
+        for (String tempCost : costs) {
+            String[] costTokens = tempCost.split("-");
+            for (String cost : costTokens) {
+                if (!Cost.isValidCost(cost)) {
+                    throw new ParseException(Cost.MESSAGE_CONSTRAINTS);
+                }
+
+                result.add(new Cost(cost));
+            }
+        }
+
+        return result;
+    }
+
+    /**
      * Parses a {@code String remark} into an {@code remark}.
      * Leading and trailing whitespaces will be trimmed.
-     * @throws ParseException if the given {@code remark} is invalid.
      */
-    public static Remark parseRemark(String remark) throws ParseException {
+    public static Remark parseRemark(String remark) {
         requireNonNull(remark);
         String trimmedRemark = remark.trim();
         return new Remark(trimmedRemark);

--- a/src/main/java/seedu/moneygowhere/model/spending/Cost.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Cost.java
@@ -29,11 +29,11 @@ public class Cost {
     public Cost(String cost) {
         requireNonNull(cost);
         checkArgument(isValidCost(cost), MESSAGE_CONSTRAINTS);
-        value = cost;
+        value = String.format("%.2f", Double.parseDouble(cost));
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid cost.
      */
     public static boolean isValidCost(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/moneygowhere/model/spending/CostInRangePredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/CostInRangePredicate.java
@@ -14,7 +14,7 @@ public class CostInRangePredicate implements Predicate<Spending> {
         this.maxCost = Double.parseDouble(maxCost.value);
 
         if (this.minCost > this.maxCost) {
-            throw new RuntimeException("This should not happen");
+            throw new IllegalArgumentException("Min cost should not be larger than max cost");
         }
     }
 

--- a/src/main/java/seedu/moneygowhere/model/spending/CostInRangePredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/CostInRangePredicate.java
@@ -1,0 +1,35 @@
+package seedu.moneygowhere.model.spending;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Spending}'s {@code Cost} matches the given cost range.
+ */
+public class CostInRangePredicate implements Predicate<Spending> {
+    private final double minCost;
+    private final double maxCost;
+
+    public CostInRangePredicate(Cost minCost, Cost maxCost) {
+        this.minCost = Double.parseDouble(minCost.value);
+        this.maxCost = Double.parseDouble(maxCost.value);
+
+        if (this.minCost > this.maxCost) {
+            throw new RuntimeException("This should not happen");
+        }
+    }
+
+    @Override
+    public boolean test(Spending spending) {
+        double cost = Double.parseDouble(spending.getCost().value);
+        return cost >= minCost && cost <= maxCost;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CostInRangePredicate // instanceof handles nulls
+                && minCost == ((CostInRangePredicate) other).minCost
+                && maxCost == ((CostInRangePredicate) other).maxCost); // state check
+    }
+
+}

--- a/src/main/java/seedu/moneygowhere/model/spending/Date.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Date.java
@@ -13,9 +13,8 @@ import seedu.moneygowhere.logic.parser.exceptions.ParseException;
  */
 public class Date implements Comparable<Date> {
 
-
     public static final String MESSAGE_CONSTRAINTS =
-            "Date numbers can be today, yesterday, tomorrow or a formal date DD/MM/YYYY.";
+            "Date numbers can be today, yesterday, tomorrow or a formal date: DD/MM/YYYY, DD-MM-YYYY or YYYY-MM-DD.";
     public final String value;
     public final LocalDate dateValue;
 

--- a/src/main/java/seedu/moneygowhere/model/spending/Date.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Date.java
@@ -3,6 +3,7 @@ package seedu.moneygowhere.model.spending;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 import seedu.moneygowhere.commons.util.DateUtil;
 import seedu.moneygowhere.logic.parser.exceptions.ParseException;
@@ -56,7 +57,7 @@ public class Date implements Comparable<Date> {
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value, dateValue);
     }
 
     @Override

--- a/src/main/java/seedu/moneygowhere/model/spending/Date.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Date.java
@@ -2,6 +2,8 @@ package seedu.moneygowhere.model.spending;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
+
 import seedu.moneygowhere.commons.util.DateUtil;
 import seedu.moneygowhere.logic.parser.exceptions.ParseException;
 
@@ -9,13 +11,13 @@ import seedu.moneygowhere.logic.parser.exceptions.ParseException;
  * Represents a Spending's Date in MoneyGoWhere.
  * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
  */
-public class Date {
+public class Date implements Comparable<Date> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
             "Date numbers can be today, yesterday, tomorrow or a formal date DD/MM/YYYY.";
-    //public static final String VALIDATION_REGEX = "([0-9]{1,2})([/\\-])([0-9]{1,2})([/\\-])([0-9]{4})";
     public final String value;
+    public final LocalDate dateValue;
 
     /**
      * Constructs a {@code Date}.
@@ -25,14 +27,13 @@ public class Date {
     public Date(String date) {
         requireNonNull(date);
 
-        java.util.Date parsedDate;
         try {
-            parsedDate = DateUtil.parseDate(date);
+            dateValue = DateUtil.parseDate(date);
         } catch (ParseException e) {
             throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
         }
 
-        value = DateUtil.formatDate(parsedDate);
+        value = DateUtil.formatDate(dateValue);
     }
 
     /**
@@ -57,6 +58,11 @@ public class Date {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(Date other) {
+        return dateValue.compareTo(other.dateValue);
     }
 
 }

--- a/src/main/java/seedu/moneygowhere/model/spending/DateInRangePredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/DateInRangePredicate.java
@@ -1,0 +1,30 @@
+package seedu.moneygowhere.model.spending;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Spending}'s {@code Date} matches any of the keywords given.
+ */
+public class DateInRangePredicate implements Predicate<Spending> {
+    private final Date startDate;
+    private final Date endDate;
+
+    public DateInRangePredicate(Date startDate, Date endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    @Override
+    public boolean test(Spending spending) {
+        return spending.getDate().compareTo(startDate) >= 0 && spending.getDate().compareTo(endDate) <= 0;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DateInRangePredicate // instanceof handles nulls
+                && startDate.equals(((DateInRangePredicate) other).startDate)
+                && endDate.equals(((DateInRangePredicate) other).endDate)); // state check
+    }
+
+}

--- a/src/main/java/seedu/moneygowhere/model/spending/Name.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Name.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.moneygowhere.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's name in the MoneyGoWhere list.
+ * Represents a Spending's name in the MoneyGoWhere list.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {

--- a/src/main/java/seedu/moneygowhere/model/spending/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/NameContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.moneygowhere.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Spending}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Spending> {
     private final List<String> keywords;

--- a/src/main/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.moneygowhere.model.spending;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.moneygowhere.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Spending}'s {@code Remark} matches any of the keywords given.
+ */
+public class RemarkContainsKeywordsPredicate implements Predicate<Spending> {
+    private final List<String> keywords;
+
+    public RemarkContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Spending spending) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(spending.getRemark().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemarkContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((RemarkContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/moneygowhere/model/spending/Spending.java
+++ b/src/main/java/seedu/moneygowhere/model/spending/Spending.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import seedu.moneygowhere.model.tag.Tag;
 
 /**
- * Represents a Person in the MoneyGoWhere list.
+ * Represents a Spending in the MoneyGoWhere list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Spending {

--- a/src/main/java/seedu/moneygowhere/model/tag/TagPredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/tag/TagPredicate.java
@@ -1,5 +1,6 @@
 package seedu.moneygowhere.model.tag;
 
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.moneygowhere.model.spending.Spending;
@@ -8,22 +9,28 @@ import seedu.moneygowhere.model.spending.Spending;
  * Tests that a {@code Spending}'s {@code Tag} matches any of the keywords given.
  */
 public class TagPredicate implements Predicate<Spending> {
-    private final String tag;
+    private final Set<String> tags;
 
-    public TagPredicate(String tag) {
-        this.tag = tag;
+    public TagPredicate(Set<String> tag) {
+        this.tags = tag;
     }
 
     @Override
     public boolean test(Spending spending) {
-        return spending.getTags().stream().anyMatch(s -> s.tagName.equalsIgnoreCase(tag));
+        for (Tag spendingTag : spending.getTags()) {
+            if (tags.contains(spendingTag.tagName.toLowerCase())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TagPredicate // instanceof handles nulls
-                && tag.equals(((TagPredicate) other).tag)); // state check
+                && tags.equals(((TagPredicate) other).tags)); // state check
     }
 
 }

--- a/src/main/java/seedu/moneygowhere/model/tag/TagPredicate.java
+++ b/src/main/java/seedu/moneygowhere/model/tag/TagPredicate.java
@@ -1,0 +1,29 @@
+package seedu.moneygowhere.model.tag;
+
+import java.util.function.Predicate;
+
+import seedu.moneygowhere.model.spending.Spending;
+
+/**
+ * Tests that a {@code Spending}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagPredicate implements Predicate<Spending> {
+    private final String tag;
+
+    public TagPredicate(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public boolean test(Spending spending) {
+        return spending.getTags().stream().anyMatch(s -> s.tagName.equalsIgnoreCase(tag));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagPredicate // instanceof handles nulls
+                && tag.equals(((TagPredicate) other).tag)); // state check
+    }
+
+}

--- a/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
@@ -35,11 +35,16 @@ class DateUtilTest {
 
     @Test
     public void parseDate_isValidDate_correctResult() {
+        // Valid dates
+        assertTrue(DateUtil.isValidDate("2/2"));
+        assertTrue(DateUtil.isValidDate("2-2"));
+
+        // Invalid dates
         assertFalse(DateUtil.isValidDate("1"));
         assertFalse(DateUtil.isValidDate("2"));
         assertFalse(DateUtil.isValidDate("2/2/79"));
-        assertTrue(DateUtil.isValidDate("2/2"));
-        assertTrue(DateUtil.isValidDate("2-2"));
+        assertFalse(DateUtil.isValidDate("31/2/2019"));
+        assertFalse(DateUtil.isValidDate("31-2-2019"));
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -22,25 +22,14 @@ class DateUtilTest {
 
     @Test
     public void parseDate_validDate_correctResult() throws ParseException {
-        Calendar c = Calendar.getInstance();
-        c.set(2019, Calendar.DECEMBER, 25, 0, 0, 0);
-
-        Date date = c.getTime();
-
-        // Manually fix the date so Natty passes.
+        LocalDate date = LocalDate.of(2019, Month.DECEMBER, 25);
         // mm/dd/yyyy will not be supported.
-        Date parsedDate2 = DateUtil.parseDate("25/12/2019 midnight");
-        assertEquals(DateUtil.formatDate(date), DateUtil.formatDate(parsedDate2));
+        assertEquals(date, DateUtil.parseDate("25/12/2019 midnight"));
 
-        c.set(2019, Calendar.OCTOBER, 12, 0, 0, 0);
-        date = c.getTime();
+        date = LocalDate.of(2019, Month.OCTOBER, 12);
 
-        Date parsedDate3 = DateUtil.parseDate("12/10/2019 midnight");
-        assertEquals(DateUtil.formatDate(date), DateUtil.formatDate(parsedDate3));
-
-        Date parsedDate4 = DateUtil.parseDate("12-10-2019 midnight");
-        assertEquals(DateUtil.formatDate(date), DateUtil.formatDate(parsedDate4));
-
+        assertEquals(date, DateUtil.parseDate("12/10/2019 midnight"));
+        assertEquals(date, DateUtil.parseDate("12-10-2019 midnight"));
         assertThrows(ParseException.class, () -> DateUtil.parseDate("does not work"));
     }
 
@@ -54,30 +43,31 @@ class DateUtilTest {
     }
 
     @Test
+    public void formatDate_correctResult() {
+        assertEquals("25/12/2019", DateUtil.formatDate(LocalDate.of(2019, Month.DECEMBER, 25)));
+    }
+
+    @Test
     public void prettyFormatDate_correctResult() {
         assertEquals("Wed 25/12/2019", DateUtil.prettyFormatDate("25/12/2019"));
         assertEquals("", DateUtil.prettyFormatDate(" "));
-
     }
 
     @Test
     public void parseDates_validDates() {
-        Calendar c = Calendar.getInstance();
-        c.set(2019, Calendar.OCTOBER, 12, 0, 0, 0);
-        Date date1 = c.getTime();
-        c.set(2019, Calendar.OCTOBER, 13, 0, 0, 0);
-        Date date2 = c.getTime();
+        LocalDate date1 = LocalDate.of(2019, Month.OCTOBER, 12);
+        LocalDate date2 = LocalDate.of(2019, Month.OCTOBER, 13);
 
-        List<Date> dates = DateUtil.parseDates("12/10 - 13/10");
+        List<LocalDate> dates = DateUtil.parseDates("12/10 - 13/10");
         assertNotNull(dates);
         assertEquals(2, dates.size());
-        assertEquals(DateUtil.formatDate(date1), DateUtil.formatDate(dates.get(0)));
-        assertEquals(DateUtil.formatDate(date2), DateUtil.formatDate(dates.get(1)));
+        assertEquals(date1, dates.get(0));
+        assertEquals(date2, dates.get(1));
     }
 
     @Test
     public void parseDates_invalidDates() {
-        List<Date> dates = DateUtil.parseDates("no");
+        List<LocalDate> dates = DateUtil.parseDates("no");
         assertNull(dates);
     }
 }

--- a/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
@@ -38,6 +38,9 @@ class DateUtilTest {
         Date parsedDate3 = DateUtil.parseDate("12/10/2019 midnight");
         assertEquals(DateUtil.formatDate(date), DateUtil.formatDate(parsedDate3));
 
+        Date parsedDate4 = DateUtil.parseDate("12-10-2019 midnight");
+        assertEquals(DateUtil.formatDate(date), DateUtil.formatDate(parsedDate4));
+
         assertThrows(ParseException.class, () -> DateUtil.parseDate("does not work"));
     }
 
@@ -47,6 +50,7 @@ class DateUtilTest {
         assertFalse(DateUtil.isValidDate("2"));
         assertFalse(DateUtil.isValidDate("2/2/79"));
         assertTrue(DateUtil.isValidDate("2/2"));
+        assertTrue(DateUtil.isValidDate("2-2"));
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/moneygowhere/commons/util/DateUtilTest.java
@@ -2,11 +2,14 @@ package seedu.moneygowhere.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,5 +54,26 @@ class DateUtilTest {
         assertEquals("Wed 25/12/2019", DateUtil.prettyFormatDate("25/12/2019"));
         assertEquals("", DateUtil.prettyFormatDate(" "));
 
+    }
+
+    @Test
+    public void parseDates_validDates() {
+        Calendar c = Calendar.getInstance();
+        c.set(2019, Calendar.OCTOBER, 12, 0, 0, 0);
+        Date date1 = c.getTime();
+        c.set(2019, Calendar.OCTOBER, 13, 0, 0, 0);
+        Date date2 = c.getTime();
+
+        List<Date> dates = DateUtil.parseDates("12/10 - 13/10");
+        assertNotNull(dates);
+        assertEquals(2, dates.size());
+        assertEquals(DateUtil.formatDate(date1), DateUtil.formatDate(dates.get(0)));
+        assertEquals(DateUtil.formatDate(date2), DateUtil.formatDate(dates.get(1)));
+    }
+
+    @Test
+    public void parseDates_invalidDates() {
+        List<Date> dates = DateUtil.parseDates("no");
+        assertNull(dates);
     }
 }

--- a/src/test/java/seedu/moneygowhere/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/commands/FindCommandTest.java
@@ -10,8 +10,11 @@ import static seedu.moneygowhere.testutil.TypicalSpendings.ELLE;
 import static seedu.moneygowhere.testutil.TypicalSpendings.FIONA;
 import static seedu.moneygowhere.testutil.TypicalSpendings.getTypicalSpendingBook;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +22,7 @@ import seedu.moneygowhere.model.Model;
 import seedu.moneygowhere.model.ModelManager;
 import seedu.moneygowhere.model.UserPrefs;
 import seedu.moneygowhere.model.spending.NameContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.Spending;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -34,14 +38,16 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+        predicates.add(firstPredicate);
+
+        FindCommand findFirstCommand = new FindCommand(predicates);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(predicates);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -50,15 +56,35 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different Spending -> returns false
+        // different predicate list -> returns false
+        List<Predicate<Spending>> secondPredicateList = new ArrayList<>();
+        secondPredicateList.add(secondPredicate);
+
+        FindCommand findSecondCommand = new FindCommand(secondPredicateList);
         assertFalse(findFirstCommand.equals(findSecondCommand));
+    }
+
+    @Test
+    public void execute_emptyPredicate_noSpendingFound() {
+        String expectedMessage = String.format(MESSAGE_SPENDINGS_LISTED_OVERVIEW, 0);
+
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+
+        FindCommand command = new FindCommand(predicates);
+        expectedModel.updateFilteredSpendingList(failed -> false);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredSpendingList());
     }
 
     @Test
     public void execute_zeroKeywords_noSpendingFound() {
         String expectedMessage = String.format(MESSAGE_SPENDINGS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+        predicates.add(predicate);
+
+        FindCommand command = new FindCommand(predicates);
         expectedModel.updateFilteredSpendingList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredSpendingList());
@@ -68,7 +94,10 @@ public class FindCommandTest {
     public void execute_multipleKeywords_multipleSpendingsFound() {
         String expectedMessage = String.format(MESSAGE_SPENDINGS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+        predicates.add(predicate);
+
+        FindCommand command = new FindCommand(predicates);
         expectedModel.updateFilteredSpendingList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredSpendingList());

--- a/src/test/java/seedu/moneygowhere/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/parser/FindCommandParserTest.java
@@ -17,6 +17,7 @@ import static seedu.moneygowhere.logic.parser.CommandParserTestUtil.assertParseS
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -74,7 +75,7 @@ public class FindCommandParserTest {
 
         // Tag
         predicates = new ArrayList<>();
-        predicates.add(new TagPredicate(VALID_TAG_FRIEND));
+        predicates.add(new TagPredicate(Set.of(VALID_TAG_FRIEND)));
         expectedFindCommand = new FindCommand(predicates);
         assertParseSuccess(parser, " " + PREFIX_TAG + VALID_TAG_FRIEND, expectedFindCommand);
     }

--- a/src/test/java/seedu/moneygowhere/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/parser/FindCommandParserTest.java
@@ -1,15 +1,35 @@
 package seedu.moneygowhere.logic.parser;
 
 import static seedu.moneygowhere.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.moneygowhere.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
+import static seedu.moneygowhere.logic.commands.CommandTestUtil.VALID_COST_AMY;
+import static seedu.moneygowhere.logic.commands.CommandTestUtil.VALID_COST_BOB;
+import static seedu.moneygowhere.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static seedu.moneygowhere.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_COST;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.moneygowhere.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.moneygowhere.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.moneygowhere.logic.commands.FindCommand;
+import seedu.moneygowhere.model.spending.Cost;
+import seedu.moneygowhere.model.spending.CostInRangePredicate;
+import seedu.moneygowhere.model.spending.Date;
+import seedu.moneygowhere.model.spending.DateInRangePredicate;
 import seedu.moneygowhere.model.spending.NameContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.RemarkContainsKeywordsPredicate;
+import seedu.moneygowhere.model.spending.Spending;
+import seedu.moneygowhere.model.tag.TagPredicate;
 
 public class FindCommandParserTest {
 
@@ -23,12 +43,51 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+        predicates.add(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        FindCommand expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice \n \t Bob  \t", expectedFindCommand);
+
+        // two predicates to avoid '==' bug
+        predicates = new ArrayList<>();
+        predicates.add(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+        predicates.add(new DateInRangePredicate(new Date("01/01/2019"), new Date("02/01/2019")));
+        expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob " + PREFIX_DATE
+                + "d/01/01/2019 - 02/01/2019", expectedFindCommand);
+
+        // Cost
+        predicates = new ArrayList<>();
+        predicates.add(new CostInRangePredicate(new Cost(VALID_COST_BOB), new Cost(VALID_COST_AMY)));
+        expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " " + PREFIX_COST + VALID_COST_BOB + "-"
+                + VALID_COST_AMY, expectedFindCommand);
+
+        // Remark
+        predicates = new ArrayList<>();
+        predicates.add(new RemarkContainsKeywordsPredicate(Arrays.asList(VALID_REMARK_AMY.split("\\s+"))));
+        expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " " + PREFIX_REMARK + VALID_REMARK_AMY, expectedFindCommand);
+
+        // Tag
+        predicates = new ArrayList<>();
+        predicates.add(new TagPredicate(VALID_TAG_FRIEND));
+        expectedFindCommand = new FindCommand(predicates);
+        assertParseSuccess(parser, " " + PREFIX_TAG + VALID_TAG_FRIEND, expectedFindCommand);
     }
 
+    @Test
+    public void parse_invalidArgs_failure() {
+        // invalid date
+        assertParseFailure(parser, INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS);
+
+        // one Date only
+        assertParseFailure(parser, " " + PREFIX_DATE + "1/1/2019", Date.MESSAGE_CONSTRAINTS);
+
+        // Cost max > min
+        assertParseFailure(parser, " " + PREFIX_COST + "2.00-1.00", Cost.MESSAGE_CONSTRAINTS);
+    }
 }

--- a/src/test/java/seedu/moneygowhere/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/parser/ParserUtilTest.java
@@ -123,7 +123,7 @@ public class ParserUtilTest {
     @Test
     public void parseDates_collectionWithValidDates_returnsDateSet() throws Exception {
         List<Date> actualDateList = ParserUtil.parseDates(Arrays.asList(VALID_DATE_1, VALID_DATE_2));
-        List<Date> expectedDateList = new ArrayList<Date>(Arrays.asList(new Date(VALID_DATE_1),
+        List<Date> expectedDateList = new ArrayList<>(Arrays.asList(new Date(VALID_DATE_1),
             new Date(VALID_DATE_2)));
 
         assertEquals(expectedDateList, actualDateList);
@@ -150,6 +150,35 @@ public class ParserUtilTest {
         String costWithWhitespace = WHITESPACE + VALID_COST + WHITESPACE;
         Cost expectedCost = new Cost(VALID_COST);
         assertEquals(expectedCost, ParserUtil.parseCost(costWithWhitespace));
+    }
+
+    @Test
+    public void parseCosts_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseCosts(null));
+    }
+
+    @Test
+    public void parseCosts_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCosts(Collections.singletonList(INVALID_COST)));
+        assertThrows(ParseException.class, () -> ParserUtil.parseCosts(Collections.singletonList("123.000-123.00")));
+    }
+
+    @Test
+    public void parseCosts_validValueWithoutWhitespace_returnsCost() throws Exception {
+        Cost expectedCost = new Cost(VALID_COST);
+        List<Cost> costs = ParserUtil.parseCosts(Collections.singletonList(VALID_COST));
+        assertEquals(1, costs.size());
+        assertEquals(expectedCost, costs.get(0));
+    }
+
+    @Test
+    public void parseCosts_validValueWithWhitespace_returnsTrimmedCost() throws Exception {
+        String costWithWhitespace = WHITESPACE + VALID_COST + WHITESPACE;
+        Cost expectedCost = new Cost(VALID_COST);
+
+        List<Cost> costs = ParserUtil.parseCosts(Collections.singletonList(costWithWhitespace));
+        assertEquals(1, costs.size());
+        assertEquals(expectedCost, costs.get(0));
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/logic/parser/SpendingBookParserTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/parser/SpendingBookParserTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.moneygowhere.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.moneygowhere.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.moneygowhere.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.moneygowhere.testutil.Assert.assertThrows;
 import static seedu.moneygowhere.testutil.TypicalIndexes.INDEX_FIRST_SPENDING;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -77,8 +79,10 @@ public class SpendingBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + String.join(" ", keywords));
+        List<Predicate<Spending>> predicates = new ArrayList<>();
+        predicates.add(new NameContainsKeywordsPredicate(keywords));
+        assertEquals(new FindCommand(predicates), command);
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/model/spending/CostInRangePredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/CostInRangePredicateTest.java
@@ -27,7 +27,7 @@ public class CostInRangePredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate == null);
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/model/spending/CostInRangePredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/CostInRangePredicateTest.java
@@ -1,0 +1,58 @@
+package seedu.moneygowhere.model.spending;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.moneygowhere.testutil.SpendingBuilder;
+
+public class CostInRangePredicateTest {
+
+    @Test
+    public void equals() {
+        Cost min = new Cost("1.00");
+        Cost max = new Cost("2.00");
+        CostInRangePredicate firstPredicate = new CostInRangePredicate(min, max);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        CostInRangePredicate firstPredicateCopy = new CostInRangePredicate(min, max);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void test_costInRange_returnsTrue() {
+        Cost min = new Cost("1.00");
+        Cost max = new Cost("3.00");
+
+        // Cost within range
+        CostInRangePredicate predicate = new CostInRangePredicate(min, max);
+        assertTrue(predicate.test(new SpendingBuilder().withCost("1.00").build()));
+        assertTrue(predicate.test(new SpendingBuilder().withCost("2.00").build()));
+        assertTrue(predicate.test(new SpendingBuilder().withCost("3.00").build()));
+    }
+
+    @Test
+    public void test_dateOutOfRange_returnsFalse() {
+        Cost min = new Cost("1.00");
+        Cost max = new Cost("3.00");
+
+        // Cost out of range
+        CostInRangePredicate predicate = new CostInRangePredicate(min, max);
+        assertFalse(predicate.test(new SpendingBuilder().withCost("4.00").build()));
+
+        // invalid predicate
+        assertThrows(RuntimeException.class, () -> new CostInRangePredicate(new Cost("2.00"),
+                new Cost("1.00")));
+    }
+}

--- a/src/test/java/seedu/moneygowhere/model/spending/DateInRangePredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/DateInRangePredicateTest.java
@@ -27,7 +27,7 @@ public class DateInRangePredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate == null);
     }
 
     @Test

--- a/src/test/java/seedu/moneygowhere/model/spending/DateInRangePredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/DateInRangePredicateTest.java
@@ -1,0 +1,54 @@
+package seedu.moneygowhere.model.spending;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.moneygowhere.testutil.SpendingBuilder;
+
+public class DateInRangePredicateTest {
+
+    @Test
+    public void equals() {
+        Date start = new Date("1/1/2019");
+        Date end = new Date("2/1/2019");
+
+        DateInRangePredicate firstPredicate = new DateInRangePredicate(start, end);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        DateInRangePredicate firstPredicateCopy = new DateInRangePredicate(start, end);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void test_dateInRange_returnsTrue() {
+        Date start = new Date("1/1/2019");
+        Date end = new Date("3/1/2019");
+
+        // Date within range
+        DateInRangePredicate predicate = new DateInRangePredicate(start, end);
+        assertTrue(predicate.test(new SpendingBuilder().withDate("1/1/2019").build()));
+        assertTrue(predicate.test(new SpendingBuilder().withDate("2/1/2019").build()));
+        assertTrue(predicate.test(new SpendingBuilder().withDate("3/1/2019").build()));
+    }
+
+    @Test
+    public void test_dateOutOfRange_returnsFalse() {
+        Date start = new Date("1/1/2019");
+        Date end = new Date("3/1/2019");
+
+        // Date out of range
+        DateInRangePredicate predicate = new DateInRangePredicate(start, end);
+        assertFalse(predicate.test(new SpendingBuilder().withDate("4/1/2019").build()));
+    }
+}

--- a/src/test/java/seedu/moneygowhere/model/spending/DateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/DateTest.java
@@ -1,5 +1,6 @@
 package seedu.moneygowhere.model.spending;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.moneygowhere.testutil.Assert.assertThrows;
@@ -33,5 +34,12 @@ public class DateTest {
         assertTrue(Date.isValidDate("25/12/2019"));
         assertTrue(Date.isValidDate("today"));
         assertTrue(Date.isValidDate("yesterday"));
+    }
+
+    @Test
+    public void compareTo() {
+        assertEquals(0, new Date("1/1/2019").compareTo(new Date("1/1/2019")));
+        assertEquals(-1, new Date("1/1/2019").compareTo(new Date("2/1/2019")));
+        assertEquals(1, new Date("2/1/2019").compareTo(new Date("1/1/2019")));
     }
 }

--- a/src/test/java/seedu/moneygowhere/model/spending/DateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/DateTest.java
@@ -38,8 +38,14 @@ public class DateTest {
 
     @Test
     public void compareTo() {
+        // Equal
         assertEquals(0, new Date("1/1/2019").compareTo(new Date("1/1/2019")));
+
+        // Less than
         assertEquals(-1, new Date("1/1/2019").compareTo(new Date("2/1/2019")));
+
+        // Greater than
         assertEquals(1, new Date("2/1/2019").compareTo(new Date("1/1/2019")));
+        assertEquals(1, new Date("12/1/2019").compareTo(new Date("1/12/2018")));
     }
 }

--- a/src/test/java/seedu/moneygowhere/model/spending/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/NameContainsKeywordsPredicateTest.java
@@ -34,7 +34,7 @@ public class NameContainsKeywordsPredicateTest {
         // null -> returns false
         assertFalse(firstPredicate.equals(null));
 
-        // different Spending -> returns false
+        // different predicate list -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 

--- a/src/test/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicateTest.java
@@ -1,0 +1,79 @@
+package seedu.moneygowhere.model.spending;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.moneygowhere.testutil.SpendingBuilder;
+
+public class RemarkContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        RemarkContainsKeywordsPredicate firstPredicate =
+                new RemarkContainsKeywordsPredicate(firstPredicateKeywordList);
+        RemarkContainsKeywordsPredicate secondPredicate =
+                new RemarkContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        RemarkContainsKeywordsPredicate firstPredicateCopy =
+                new RemarkContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different predicate list -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_remarkContainsKeywords_returnsTrue() {
+        // One keyword
+        RemarkContainsKeywordsPredicate predicate =
+                new RemarkContainsKeywordsPredicate(Collections.singletonList("watch"));
+        assertTrue(predicate.test(new SpendingBuilder().withRemark("Likes to watch movies").build()));
+
+        // Multiple keywords
+        predicate = new RemarkContainsKeywordsPredicate(Arrays.asList("watch", "movies"));
+        assertTrue(predicate.test(new SpendingBuilder().withRemark("Likes to watch movies").build()));
+
+        // Only one matching keyword
+        predicate = new RemarkContainsKeywordsPredicate(Arrays.asList("Likes", "swimming"));
+        assertTrue(predicate.test(new SpendingBuilder().withRemark("Likes movies").build()));
+
+        // Mixed-case keywords
+        predicate = new RemarkContainsKeywordsPredicate(Arrays.asList("taSty", "fOod"));
+        assertTrue(predicate.test(new SpendingBuilder().withRemark("tasty food").build()));
+    }
+
+    @Test
+    public void test_remarkDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        RemarkContainsKeywordsPredicate predicate = new RemarkContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new SpendingBuilder().withRemark("Apple").build()));
+
+        // Non-matching keyword
+        predicate = new RemarkContainsKeywordsPredicate(Collections.singletonList("Chicken"));
+        assertFalse(predicate.test(new SpendingBuilder().withRemark("Apple Briyani").build()));
+
+        // Keywords match name, date, but does not match remark
+        predicate = new RemarkContainsKeywordsPredicate(Arrays.asList("1/1/2019", "Apple"));
+        assertFalse(predicate.test(new SpendingBuilder().withName("Apple").withDate("1/1/2019")
+                .withRemark("Tasty").build()));
+    }
+}

--- a/src/test/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/spending/RemarkContainsKeywordsPredicateTest.java
@@ -35,7 +35,7 @@ public class RemarkContainsKeywordsPredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate == null);
 
         // different predicate list -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));

--- a/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
@@ -3,6 +3,8 @@ package seedu.moneygowhere.model.tag;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.moneygowhere.testutil.SpendingBuilder;
@@ -11,13 +13,14 @@ public class TagPredicateTest {
 
     @Test
     public void equals() {
-        TagPredicate firstPredicate = new TagPredicate("tag");
+        Set<String> tagKeywordSet = Set.of("tag");
+        TagPredicate firstPredicate = new TagPredicate(tagKeywordSet);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        TagPredicate firstPredicateCopy = new TagPredicate("tag");
+        TagPredicate firstPredicateCopy = new TagPredicate(tagKeywordSet);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -29,16 +32,19 @@ public class TagPredicateTest {
 
     @Test
     public void test_tagPredicate_returnsTrue() {
-        // Tag exists
-        TagPredicate predicate = new TagPredicate("one");
-        assertTrue(predicate.test(new SpendingBuilder().withTags("one").build()));
+        // Only one tag matches
+        TagPredicate predicate2 = new TagPredicate(Set.of("three"));
+        assertTrue(predicate2.test(new SpendingBuilder().withTags("one", "two", "three").build()));
+
+        // Both tags match
+        TagPredicate predicate = new TagPredicate(Set.of("one", "two"));
         assertTrue(predicate.test(new SpendingBuilder().withTags("one", "two").build()));
     }
 
     @Test
     public void test_tagPredicate_returnsFalse() {
         // Tag does not exist
-        TagPredicate predicate = new TagPredicate("one");
+        TagPredicate predicate = new TagPredicate(Set.of("one"));
         assertFalse(predicate.test(new SpendingBuilder().withTags("two").build()));
         assertFalse(predicate.test(new SpendingBuilder().withTags("three", "two").build()));
     }

--- a/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
@@ -1,0 +1,45 @@
+package seedu.moneygowhere.model.tag;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.moneygowhere.testutil.SpendingBuilder;
+
+public class TagPredicateTest {
+
+    @Test
+    public void equals() {
+        TagPredicate firstPredicate = new TagPredicate("tag");
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagPredicate firstPredicateCopy = new TagPredicate("tag");
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void test_tagPredicate_returnsTrue() {
+        // Tag exists
+        TagPredicate predicate = new TagPredicate("one");
+        assertTrue(predicate.test(new SpendingBuilder().withTags("one").build()));
+        assertTrue(predicate.test(new SpendingBuilder().withTags("one", "two").build()));
+    }
+
+    @Test
+    public void test_tagPredicate_returnsFalse() {
+        // Tag does not exist
+        TagPredicate predicate = new TagPredicate("one");
+        assertFalse(predicate.test(new SpendingBuilder().withTags("two").build()));
+        assertFalse(predicate.test(new SpendingBuilder().withTags("three", "two").build()));
+    }
+}

--- a/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
+++ b/src/test/java/seedu/moneygowhere/model/tag/TagPredicateTest.java
@@ -24,7 +24,7 @@ public class TagPredicateTest {
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate == null);
     }
 
     @Test


### PR DESCRIPTION
- Updated find command to accept multiple arguments: `find n/KEYWORDS d/DATE_RANGE c/COST_RANGE r/REMARK t/TAG_KEYWORDS`. At least one field is required, but if any are combined, it means "and".
- Find now uses a predicate list rather than a single predicate
- Updated Date to LocalDate based on new Java API
- Normalised costs for storage purposes
- Fixed some javadoc comments
- Tag keywords are stored in a hashset for O(1) lookup time
- Multiple tags can be searched in one tag command: `t/food entertainment leisure` will return tags `['food', 'entertainment', 'leisure']`
- Updated user guide

completes #25 
intermediate implementation to #23 #24 #26 