### PR TITLE
prevent user from entering `budget 0.000000001`

### DIFF
--- a/src/main/java/seedu/moneygowhere/logic/commands/BudgetCommand.java
+++ b/src/main/java/seedu/moneygowhere/logic/commands/BudgetCommand.java
@@ -33,6 +33,7 @@ public class BudgetCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+
         Currency currencyInUse = model.getCurrencyInUse();
 
         double budgetAmount = budget.getAmount();
@@ -42,7 +43,9 @@ public class BudgetCommand extends Command {
             budget = new Budget(budgetAmount / currencyInUse.rate);
         }
 
-        if (budget.getAmount() < 0 || budget.getAmount() > 1000000000) {
+        if (budget.getAmount() < 0 || budget.getAmount() > 1000000000
+                // to prevent user input of 0.0000001, which is displayed as 0
+                || (budget.getAmount() != 0 && budget.getAmount() < 0.01)) {
             throw new CommandException(Messages.MESSAGE_INVALID_BUDGET_AMOUNT);
         }
 

--- a/src/test/java/seedu/moneygowhere/logic/commands/BudgetCommandTest.java
+++ b/src/test/java/seedu/moneygowhere/logic/commands/BudgetCommandTest.java
@@ -38,8 +38,18 @@ class BudgetCommandTest {
     }
 
     @Test
-    public void execute_invalidBudgetAmount_fail() {
+    public void execute_veryLargeBudgetAmount_fail() {
         Budget budget = new Budget(1000000001);
+        BudgetCommand budgetCommand = new BudgetCommand(budget);
+
+        String expectedMessage = Messages.MESSAGE_INVALID_BUDGET_AMOUNT;
+
+        assertCommandFailure(budgetCommand, model , expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidBudgetAmount_fail() {
+        Budget budget = new Budget(0.0000000000000000001);
         BudgetCommand budgetCommand = new BudgetCommand(budget);
 
         String expectedMessage = Messages.MESSAGE_INVALID_BUDGET_AMOUNT;


### PR DESCRIPTION
prevent user from entering `budget 0.000000001`, but making sure the input is not less than 0.01
fixes #243 